### PR TITLE
implemented foreach. (each)

### DIFF
--- a/src/Fusonic/Linq/Linq.php
+++ b/src/Fusonic/Linq/Linq.php
@@ -317,6 +317,20 @@ class Linq implements IteratorAggregate
     }
 
     /**
+     * Performs the specified action on each element of the Linq sequence and returns the Linq sequence.
+     * @param callback $func    A func that will be evaluated for each item in the linq sequence.
+     * @return Linq             The original Linq sequence that was used to perform the foreach.
+     */
+    public function each($func)
+    {
+        foreach($this->iterator as $item)
+        {
+            $func($item);
+        }
+        return $this;
+    }
+
+    /**
      * Concatenates this Linq object with the given sequence.
      *
      * @param array|Iterator $second A sequence which will be concatenated with this Linq object.

--- a/tests/Fusonic/Linq/Test/LinqTest.php
+++ b/tests/Fusonic/Linq/Test/LinqTest.php
@@ -1366,6 +1366,31 @@ class LinqTest extends PHPUnit_Framework_TestCase
         }, self::ExceptionName_UnexpectedValue);
     }
 
+    public function testEach_PerformsActionOnEachElement()
+    {
+        $items = array("a", "b", "c");
+        $looped = array();
+        Linq::from($items)
+            ->each(function($x) use(&$looped)
+            {
+               $looped[] = $x;
+            });
+
+        $this->assertEquals(3, count($looped));
+        $this->assertEquals("a", $looped[0]);
+        $this->assertEquals("b", $looped[1]);
+        $this->assertEquals("c", $looped[2]);
+    }
+
+    public function testEach_ReturnsOriginalLinqSequence()
+    {
+        $linq = Linq::from(array(1,2,3,4))
+            ->skip(2)->take(1);
+
+        $linqAfterEach = $linq->each(function($x) {});
+        $this->assertSame($linq, $linqAfterEach);
+    }
+
     private function assertException($closure, $expected = self::ExceptionName_Runtime)
     {
         try


### PR DESCRIPTION
This adds a foreach method. Method signature is "each" because "foreach" cannot be used as it is a reserved keyword in php.

Usage:

```
 $items = array("a", "b", "c");
        Linq::from($items)
            ->each(function($x)
            {
            });
```
