### PR TITLE
Add support for DateTime values in min/max operations

### DIFF
--- a/src/Fusonic/Linq/Linq.php
+++ b/src/Fusonic/Linq/Linq.php
@@ -345,8 +345,8 @@ class Linq implements IteratorAggregate
         $min = null;
         $iterator = $this->getSelectIteratorOrInnerIterator($func);
         foreach ($iterator as $value) {
-            if (!is_numeric($value) && !is_string($value)) {
-                throw new UnexpectedValueException("min() only works on numeric values or strings.");
+            if (!is_numeric($value) && !is_string($value) && !($value instanceof \DateTime)) {
+                throw new UnexpectedValueException("min() only works on numeric values, strings and DateTime objects.");
             }
 
             if (is_null($min)) {
@@ -376,8 +376,8 @@ class Linq implements IteratorAggregate
         $max = null;
         $iterator = $this->getSelectIteratorOrInnerIterator($func);
         foreach ($iterator as $value) {
-            if (!is_numeric($value) && !is_string($value)) {
-                throw new UnexpectedValueException("max() only works on numeric values or strings.");
+            if (!is_numeric($value) && !is_string($value) && !($value instanceof \DateTime)) {
+                throw new UnexpectedValueException("max() only works on numeric values, strings and DateTime objects.");
             }
 
             if (is_null($max)) {
@@ -388,7 +388,7 @@ class Linq implements IteratorAggregate
         }
 
         if ($max === null) {
-            throw new \RuntimeException("Cannot calculate min() as the Linq sequence contains no elements.");
+            throw new \RuntimeException("Cannot calculate max() as the Linq sequence contains no elements.");
         }
 
         return $max;

--- a/tests/Fusonic/Linq/Test/LinqTest.php
+++ b/tests/Fusonic/Linq/Test/LinqTest.php
@@ -1241,6 +1241,17 @@ class LinqTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("a", $min);
     }
 
+    public function testMin_ReturnsMinValueFromDateTimes()
+    {
+        $items = array(
+            new DateTime("2015-01-01 10:00:00"),
+            new DateTime("2015-02-01 10:00:00"),
+            new DateTime("2015-01-01 09:00:00"),
+        );
+        $min = Linq::from($items)->min();
+        $this->assertEquals($items[2], $min);
+    }
+
     public function testMin_ThrowsExceptionIfSequenceIsEmpty()
     {
         $this->assertException(function()
@@ -1302,6 +1313,17 @@ class LinqTest extends PHPUnit_Framework_TestCase
         $items = array(-12, 0, 100, -33);
         $max = Linq::from($items)->max();
         $this->assertEquals(100, $max);
+    }
+
+    public function testMax_ReturnsMaxValueFromDateTimes()
+    {
+        $items = array(
+            new DateTime("2015-01-01 10:00:00"),
+            new DateTime("2015-02-01 10:00:00"),
+            new DateTime("2015-01-01 09:00:00"),
+        );
+        $max = Linq::from($items)->max();
+        $this->assertEquals($items[1], $max);
     }
 
     public function testSum_ThrowsExceptionIfSequenceContainsNoneNumericValues()


### PR DESCRIPTION
This change allows execution of `min()` and `max()` operations on `\DateTime` values.