### PR TITLE
Implement chunking without use of group iterator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
 install: composer install

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ LINQ queries offer three main advantages over traditional foreach loops:
 
 ## Requirements
 
-fusonic/linq is supported on PHP 5.3 and up.
+fusonic/linq is supported on PHP 5.5 and up.
 
 
 ## Installation & Usage
@@ -202,6 +202,6 @@ Linq::from(array(1, 2, "Not a numeric value"))
 You can run the test suite with the following command:
 
 ```bash
-phpunit --bootstrap tests/bootstrap.php .
+vendor/bin/phpunit --bootstrap tests/bootstrap.php .
 ``` 
 

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,14 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-0": {
             "Fusonic\\Linq": "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^4.0"
     }
 }

--- a/src/Fusonic/Linq/Iterator/ChunkIterator.php
+++ b/src/Fusonic/Linq/Iterator/ChunkIterator.php
@@ -44,8 +44,6 @@ class ChunkIterator implements Iterator
     {
         $this->iterator = $iterator;
         $this->chunkSize = $chunkSize;
-
-        $this->chunk = $this->getNextChunk();
     }
 
     /**

--- a/src/Fusonic/Linq/Iterator/ChunkIterator.php
+++ b/src/Fusonic/Linq/Iterator/ChunkIterator.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of Fusonic-linq.
+ * https://github.com/fusonic/fusonic-linq
+ *
+ * (c) Fusonic GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fusonic\Linq\Iterator;
+
+use Countable;
+use Fusonic\Linq\Linq;
+use Iterator;
+
+/**
+ * Iterates over an iterator, returning Linq objects of the given chunk size.
+ */
+class ChunkIterator implements Iterator, Countable
+{
+    /**
+     * @var Iterator
+     */
+    private $iterator;
+
+    /**
+     * @var int
+     */
+    private $i = 0;
+
+    /**
+     * @var int
+     */
+    private $chunkSize;
+
+    public function __construct(Iterator $iterator, $chunkSize)
+    {
+        $this->iterator = $iterator;
+        $this->chunkSize = $chunkSize;
+    }
+
+    /**
+     * @return Linq
+     * @todo Should this chunking logic stay here? This might be better in `next()` but then `current()` should return
+     *       the first chunk before we call `next()`. With current implementation, looping through without calling
+     *       `current()` is inconsistent, hence the `count()` implementation.
+     */
+    public function current()
+    {
+        $chunk = [];
+        while ($this->valid()) {
+            $chunk[] = $this->iterator->current();
+
+            if (count($chunk) < $this->chunkSize) {
+                $this->iterator->next();
+            } else {
+                break;
+            }
+        }
+
+        return new Linq($chunk);
+    }
+
+    public function next()
+    {
+        $this->iterator->next();
+        $this->i++;
+    }
+
+    public function key()
+    {
+        return $this->i;
+    }
+
+    public function valid()
+    {
+        return $this->iterator->valid();
+    }
+
+    public function rewind()
+    {
+        $this->iterator->rewind();
+        $this->i = 0;
+    }
+
+    /**
+     * Implemented to ensure tests pass.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return (int) ceil(iterator_count($this->iterator) / $this->chunkSize);
+    }
+}

--- a/src/Fusonic/Linq/Linq.php
+++ b/src/Fusonic/Linq/Linq.php
@@ -12,6 +12,7 @@
 namespace Fusonic\Linq;
 
 use Countable;
+use Fusonic\Linq\Iterator\ChunkIterator;
 use Fusonic\Linq\Iterator\ExceptIterator;
 use Fusonic\Linq\Iterator\DistinctIterator;
 use Fusonic\Linq\Iterator\GroupIterator;
@@ -176,7 +177,7 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Splits the sequence in chunks according to $chunksize.
      *
-     * @param $chunksize Specifies how many elements are grouped together per chunk.
+     * @param int $chunksize Specifies how many elements are grouped together per chunk.
      * @throws \InvalidArgumentException
      * @return Linq
      */
@@ -186,27 +187,7 @@ class Linq implements IteratorAggregate, Countable
             throw new \InvalidArgumentException("chunksize", $chunksize);
         }
 
-        $i = -1;
-        return $this->select(
-            function ($x) use (&$i) {
-                $i++;
-                return array("index" => $i, "value" => $x);
-            }
-        )
-        ->groupBy(
-            function ($pair) use ($chunksize) {
-                return $pair["index"] / $chunksize;
-            }
-        )
-        ->select(
-            function (GroupedLinq $group) {
-                return $group->select(
-                    function ($v) {
-                        return $v["value"];
-                    }
-                );
-            }
-        );
+        return Linq::from(new ChunkIterator($this->iterator, $chunksize));
     }
 
     /**

--- a/tests/Fusonic/Linq/Test/ChunkIteratorTest.php
+++ b/tests/Fusonic/Linq/Test/ChunkIteratorTest.php
@@ -33,6 +33,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $x->valid());
         $this->assertEquals([2], $x->current()->toArray());
 
+        $x->next();
         $this->assertEquals(false, $x->valid());
     }
 
@@ -51,6 +52,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $x->valid());
         $this->assertEquals(["e"], $x->current()->toArray());
 
+        $x->next();
         $this->assertEquals(false, $x->valid());
     }
 
@@ -68,5 +70,46 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
             ["0,1,2", "3,4,5", "6,7,8"],
             $arr
         );
+    }
+
+    public function testIdempotency()
+    {
+        $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
+
+        $this->assertEquals(true, $x->valid());
+        $this->assertEquals([0, 1], $x->current()->toArray());
+        $this->assertEquals([0, 1], $x->current()->toArray());
+        $x->next();
+
+        $this->assertEquals([2], $x->current()->toArray());
+        $this->assertEquals([2], $x->current()->toArray());
+    }
+
+    public function testNext()
+    {
+        $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
+
+        $x->next();
+        $this->assertEquals([2], $x->current()->toArray());
+    }
+
+    public function testKey()
+    {
+        $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
+
+        $this->assertEquals(0, $x->key());
+        $x->next();
+        $this->assertEquals(1, $x->key());
+    }
+
+    public function testRewind()
+    {
+        $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
+
+        $x->next();
+        $x->rewind();
+        $this->assertEquals(true, $x->valid());
+        $this->assertEquals(0, $x->key());
+        $this->assertEquals([0, 1], $x->current()->toArray());
     }
 }

--- a/tests/Fusonic/Linq/Test/ChunkIteratorTest.php
+++ b/tests/Fusonic/Linq/Test/ChunkIteratorTest.php
@@ -11,6 +11,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $x = new ChunkIterator(new \ArrayIterator([]), 1);
 
+        $x->rewind();
         $this->assertEquals(false, $x->valid());
     }
 
@@ -18,6 +19,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $x = new ChunkIterator(new \ArrayIterator([0, 1]), 100);
 
+        $x->rewind();
         $this->assertEquals(true, $x->valid());
         $this->assertEquals([0, 1], $x->current()->toArray());
     }
@@ -26,6 +28,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
 
+        $x->rewind();
         $this->assertEquals(true, $x->valid());
         $this->assertEquals([0, 1], $x->current()->toArray());
 
@@ -41,6 +44,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $x = new ChunkIterator(new \ArrayIterator(["a", "b", "c", "d", "e"]), 2);
 
+        $x->rewind();
         $this->assertEquals(true, $x->valid());
         $this->assertEquals(["a", "b"], $x->current()->toArray());
 
@@ -76,6 +80,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
 
+        $x->rewind();
         $this->assertEquals(true, $x->valid());
         $this->assertEquals([0, 1], $x->current()->toArray());
         $this->assertEquals([0, 1], $x->current()->toArray());
@@ -89,6 +94,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
 
+        $x->rewind();
         $x->next();
         $this->assertEquals([2], $x->current()->toArray());
     }
@@ -97,6 +103,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
 
+        $x->rewind();
         $this->assertEquals(0, $x->key());
         $x->next();
         $this->assertEquals(1, $x->key());
@@ -106,6 +113,7 @@ class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
 
+        $x->rewind();
         $x->next();
         $x->rewind();
         $this->assertEquals(true, $x->valid());

--- a/tests/Fusonic/Linq/Test/ChunkIteratorTest.php
+++ b/tests/Fusonic/Linq/Test/ChunkIteratorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Fusonic\Linq\Test;
+
+use Fusonic\Linq\Iterator\ChunkIterator;
+use Fusonic\Linq\Linq;
+
+class ChunkIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmptyIterator()
+    {
+        $x = new ChunkIterator(new \ArrayIterator([]), 1);
+
+        $this->assertEquals(false, $x->valid());
+    }
+
+    public function testChunkSizeLargerThanIterator()
+    {
+        $x = new ChunkIterator(new \ArrayIterator([0, 1]), 100);
+
+        $this->assertEquals(true, $x->valid());
+        $this->assertEquals([0, 1], $x->current()->toArray());
+    }
+
+    public function testChunkSizeSmallerThanIterator()
+    {
+        $x = new ChunkIterator(new \ArrayIterator([0, 1, 2]), 2);
+
+        $this->assertEquals(true, $x->valid());
+        $this->assertEquals([0, 1], $x->current()->toArray());
+
+        $x->next();
+        $this->assertEquals(true, $x->valid());
+        $this->assertEquals([2], $x->current()->toArray());
+
+        $this->assertEquals(false, $x->valid());
+    }
+
+    public function testCharElementsScenario()
+    {
+        $x = new ChunkIterator(new \ArrayIterator(["a", "b", "c", "d", "e"]), 2);
+
+        $this->assertEquals(true, $x->valid());
+        $this->assertEquals(["a", "b"], $x->current()->toArray());
+
+        $x->next();
+        $this->assertEquals(true, $x->valid());
+        $this->assertEquals(["c", "d"], $x->current()->toArray());
+
+        $x->next();
+        $this->assertEquals(true, $x->valid());
+        $this->assertEquals(["e"], $x->current()->toArray());
+
+        $this->assertEquals(false, $x->valid());
+    }
+
+    public function testDifferentChunkSize()
+    {
+        $x = new ChunkIterator(new \ArrayIterator([0, 1, 2, 3, 4, 5, 6, 7, 8]), 3);
+
+        $arr = array_map(
+            function (Linq $y) {
+                return implode(",", $y->toArray());
+            },
+            iterator_to_array($x)
+        );
+        $this->assertEquals(
+            ["0,1,2", "3,4,5", "6,7,8"],
+            $arr
+        );
+    }
+}

--- a/tests/Fusonic/Linq/Test/LinqTest.php
+++ b/tests/Fusonic/Linq/Test/LinqTest.php
@@ -1698,6 +1698,28 @@ class LinqTest extends PHPUnit_Framework_TestCase
             ->toArray();
     }
 
+    public function testChunkWithoutGrouping()
+    {
+        $log = [];
+        Linq::from([0, 1, 2, 3])
+            ->where(function($x) use(&$log) {
+                $log[] = 'where';
+                return true;
+            })
+            ->select(function($x) use(&$log) {
+                $log[] = 'select';
+                return $x;
+            })
+            ->chunk(2)
+            ->each(function(Linq $chunk) use(&$log) {
+                $log[] = 'each';
+                return $chunk;
+            })
+        ;
+
+        $this->assertEquals('where select where select each where select where select each', implode(' ', $log));
+    }
+
 	/**
 	 * @test
 	 */


### PR DESCRIPTION
See what you think of this. Notes on changes:

- I created another iterator `ChunkIterator`, as using `yield` on its own was not quite working as anticipated.
- I added tests for `ChunkIterator` and for the new chunking behaviour, all passing here.
- Because `yield` isn't used, earlier PHP versions could still be supported, but here I have still bumped the version requirement to 5.5.
- `ChunkIterator` seems to work okay for the purposes here, but there are some potential inconsistencies, basically a conflict between `current()` and `next()`. There's a note in the code.
- I added phpunit as a dev dependency, which can then be invoked by `vendor/bin/phpunit`. For me this works better and ensures the installed phpunit is aligned with the current project.
- Minor updates to docs where necessary, check out the diff.

Perhaps some changes are slightly opinionated but any comments or suggestions are welcome.