### PR TITLE
Use PHP 5.4 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Once installed, include vendor/autoload.php in your script to autoload fusonic/l
 require 'vendor/autoload.php';
 use Fusonic\Linq\Linq;
 
-Linq::from(array())->count();
+Linq::from([])->count();
 ```
 
 ## Examples
@@ -75,17 +75,17 @@ $result = Linq::from($users)
 
 ### Flatten multiple sequences into one sequence:
 ```php
-$array1 = array("key" => "a", "data" => array("a1", "a2"));
-$array2 = array("key" => "b", "data" => array("b1", "b2"));
-$array3 = array("key" => "c", "data" => array("c1", "c2"));
+$array1 = ["key" => "a", "data" => ["a1", "a2"]];
+$array2 = ["key" => "b", "data" => ["b1", "b2"]];
+$array3 = ["key" => "c", "data" => ["c1", "c2"]];
 
-$allArrays = array($array1, $array2, $array3);
+$allArrays = [$array1, $array2, $array3];
 
 $result = Linq::from($allArrays)
     ->selectMany(function($x) { return $x["data"]; })
     ->toArray();
     
-// $result is now: array("a1", "a2", "b1", "b2", "c1", "c2");
+// $result is now: ["a1", "a2", "b1", "b2", "c1", "c2"];
 
 ```
 ### Map sequence to array with key/value selectors:
@@ -93,26 +93,26 @@ $result = Linq::from($allArrays)
 $category1 = new stdClass(); $category1->key = 1; $category1->value = "Cars";
 $category2 = new stdClass(); $category2->key = 2; $category2->value = "Ships";
 
-$result = Linq::from(array($category1, $category2))
+$result = Linq::from([$category1, $category2])
     ->toArray(
         function($x) { return $x->key; }, // key-selector
         function($x) { return $x->value; } // value-selector
     );
             
-// $result is now: array(1 => "Cars", 2 => "Ships");
+// $result is now: [1 => "Cars", 2 => "Ships"];
 ```
 
 ### The aggregate method makes it simple to perform a calculation over a sequence of values:
 ```php
-$numbers = Linq::from(array(1,2,3,4));
+$numbers = Linq::from([1,2,3,4]);
 $sum = $numbers->aggregate(function($a, $b) { return $a + $b; });
 // echo $sum; // output: 10 (1+2+3+4)
 
-$chars = Linq::from(array("a", "b", "c"));
+$chars = Linq::from(["a", "b", "c"]);
 $csv = $chars->aggregate(function($a, $b) { return $a . "," . $b; });
 // echo $csv; // output: "a,b,c"
 
-$chars = Linq::from(array("a", "b", "c"));
+$chars = Linq::from(["a", "b", "c"]);
 $csv = $chars->aggregate(function($a, $b) { return $a . "," . $b; }, "seed");
 // echo $csv; // output: "seed,a,b,c"
 
@@ -121,7 +121,7 @@ $csv = $chars->aggregate(function($a, $b) { return $a . "," . $b; }, "seed");
 
 ### The chunk method makes it simple to split a sequence into chunks of a given size:
 ```php
-$chunks = Linq::from(array("a","b","c","d","e"))->chunk(2);
+$chunks = Linq::from(["a","b","c","d","e"])->chunk(2);
 $i = 0;
 foreach($chunk in $chunks) {
   $i++;
@@ -188,12 +188,12 @@ This means that we made this library totally predictable in what it does, and ve
 ```php
 /* Throws an UnexpectedValueException if the 
 provided callback function does not return a boolean */
-Linq::from(array("1", "1"))
+Linq::from(["1", "1"])
 ->where(function($x) { return "NOT A BOOLEAN"; });
 
 /* Throws an UnexpectedValueException if one of the values
 is not convertible to a numeric value:*/
-Linq::from(array(1, 2, "Not a numeric value"))
+Linq::from([1, 2, "Not a numeric value"])
 ->sum();
 ```
 

--- a/examples/4-order.php
+++ b/examples/4-order.php
@@ -8,10 +8,10 @@ $files = glob("/tmp/*");
 // Sort all files in a directory by filsize in descending order
 
 ### Plain PHP: ###
-$data = array();
+$data = [];
 foreach($files as $file) {
     $currentSize = filesize($file);
-    $data[] = array("name" => $file, "size" => $currentSize);
+    $data[] = ["name" => $file, "size" => $currentSize];
 }
 
 uasort($data, function($a, $b) {
@@ -31,7 +31,7 @@ foreach($data as $x)
 echo "<br/><br> Linq: <br /><br>";
 
 $linq = Linq::from($files)
-    ->select(function($x) { return array("name" => $x, "size" => filesize($x)); })
+    ->select(function($x) { return ["name" => $x, "size" => filesize($x)]; })
     ->orderByDescending(function($x) { return $x['size']; })
     ->each(function($x) {
         echo $x['name'] . " " . $x['size'] . "<br>";

--- a/examples/5-grouping.php
+++ b/examples/5-grouping.php
@@ -8,10 +8,10 @@ $files = glob("/tmp/*");
 // Group all files by its filesize.
 
 ### Plain PHP: ###
-$data = array();
+$data = [];
 foreach($files as $file) {
     $currentSize = filesize($file);
-    $data[] = array("name" => $file, "size" => $currentSize);
+    $data[] = ["name" => $file, "size" => $currentSize];
 }
 
 uasort($data, function($a, $b) {
@@ -21,14 +21,14 @@ uasort($data, function($a, $b) {
     else return $as < $bs ? 1 : -1;
 });
 
-$grouped = array();
+$grouped = [];
 foreach($data as $x)
 {
     if(isset($grouped[$x['size']])) {
         $grouped[$x['size']][] = $x;
     }
     else {
-        $grouped[$x['size']] = array($x);
+        $grouped[$x['size']] = [$x];
     }
 }
 
@@ -44,7 +44,7 @@ foreach($grouped as $key => $value) {
 echo "<br/><br> Linq: <br /><br>";
 
 $linq = Linq::from($files)
-    ->select(function($x) { return array("name" => $x, "size" => filesize($x)); })
+    ->select(function($x) { return ["name" => $x, "size" => filesize($x)]; })
     ->orderByDescending(function($x) { return $x['size']; })
     ->groupBy(function($x) { return $x['size']; })
     ->orderByDescending(function($x) { return $x->count(); })

--- a/examples/6-typesafe.php
+++ b/examples/6-typesafe.php
@@ -17,11 +17,11 @@ use Fusonic\Linq\Linq;
 
 /* Throws an UnexpectedValueException if the
 provided callback function does not return a boolean */
-Linq::from(array("1", "1"))
+Linq::from(["1", "1"])
     ->where(function($x) { return "NOT A BOOLEAN"; });
 
 
 /* Throws an UnexpectedValueException if one of the values
 is not convertible to a numeric value:*/
-Linq::from(array(1, 2, "Not a numeric value"))
+Linq::from([1, 2, "Not a numeric value"])
     ->sum();

--- a/src/Fusonic/Linq/Helper/Set.php
+++ b/src/Fusonic/Linq/Helper/Set.php
@@ -14,7 +14,7 @@ namespace Fusonic\Linq\Helper;
 
 class Set
 {
-    private $objects = array();
+    private $objects = [];
 
     /**
      * If the value is not in the set, it will be added and true is returned. otherwise false is returned.

--- a/src/Fusonic/Linq/Iterator/GroupIterator.php
+++ b/src/Fusonic/Linq/Iterator/GroupIterator.php
@@ -61,11 +61,11 @@ class GroupIterator implements Iterator
     private function doGroup()
     {
         $keySelector = $this->keySelector;
-        $this->grouped = new \ArrayIterator(array());
+        $this->grouped = new \ArrayIterator([]);
         foreach ($this->iterator as $value) {
             $key = $keySelector($value);
             if (!isset($this->grouped[$key])) {
-                $this->grouped[$key] = array('key' => $key, 'values'=> array());
+                $this->grouped[$key] = ['key' => $key, 'values'=> []];
             }
 
             $this->grouped[$key]['values'][] = $value;

--- a/src/Fusonic/Linq/Iterator/GroupIterator.php
+++ b/src/Fusonic/Linq/Iterator/GroupIterator.php
@@ -22,7 +22,7 @@ class GroupIterator implements Iterator
     private $grouped;
     private $keySelector;
 
-    public function __construct($iterator, $keySelector)
+    public function __construct($iterator, callable $keySelector)
     {
         $this->iterator = $iterator;
         $this->keySelector = $keySelector;

--- a/src/Fusonic/Linq/Iterator/OrderIterator.php
+++ b/src/Fusonic/Linq/Iterator/OrderIterator.php
@@ -87,8 +87,8 @@ class OrderIterator implements Iterator
             $sortType = Helper\LinqHelper::LINQ_ORDER_TYPE_ALPHANUMERIC;
         }
 
-        $keyMap = array();
-        $valueMap = array();
+        $keyMap = [];
+        $valueMap = [];
 
         foreach ($itemIterator as $value) {
             $orderKey = $orderKeyFunc != null ? $orderKeyFunc($value) : $value;
@@ -109,7 +109,7 @@ class OrderIterator implements Iterator
             arsort($keyMap, $sortType == Helper\LinqHelper::LINQ_ORDER_TYPE_NUMERIC ? SORT_NUMERIC : SORT_LOCALE_STRING);
         }
 
-        $sorted = new ArrayIterator(array());
+        $sorted = new ArrayIterator([]);
         foreach ($keyMap as $key => $value) {
             $sorted[] = $valueMap[$key];
         }

--- a/src/Fusonic/Linq/Iterator/OrderIterator.php
+++ b/src/Fusonic/Linq/Iterator/OrderIterator.php
@@ -25,7 +25,7 @@ class OrderIterator implements Iterator
     private $orderedIterator;
     private $orderKeyFunc;
 
-    public function __construct(Traversable $items, $orderKeyFunc, $direction)
+    public function __construct(Traversable $items, callable $orderKeyFunc, $direction)
     {
         $this->iterator = $items;
         $this->direction = $direction;

--- a/src/Fusonic/Linq/Iterator/SelectIterator.php
+++ b/src/Fusonic/Linq/Iterator/SelectIterator.php
@@ -19,7 +19,7 @@ class SelectIterator extends \IteratorIterator
 {
     private $selector;
 
-    public function __construct(Traversable $iterator, $selector)
+    public function __construct(Traversable $iterator, callable $selector)
     {
         parent::__construct($iterator);
         if ($selector === null) {

--- a/src/Fusonic/Linq/Iterator/WhereIterator.php
+++ b/src/Fusonic/Linq/Iterator/WhereIterator.php
@@ -21,7 +21,7 @@ class WhereIterator implements IteratorAggregate
     private $func;
     private $inner;
 
-    public function __construct(Traversable $inner, $func)
+    public function __construct(Traversable $inner, callable $func)
     {
         $this->inner = $inner;
         $this->func = $func;

--- a/src/Fusonic/Linq/Linq.php
+++ b/src/Fusonic/Linq/Linq.php
@@ -116,7 +116,7 @@ class Linq implements IteratorAggregate, Countable
         $innerIterator = $this->iterator;
         if ($innerIterator instanceof \ArrayIterator) {
             if ($count >= $innerIterator->count()) {
-                return new Linq(array());
+                return new Linq([]);
             }
         }
 
@@ -132,7 +132,7 @@ class Linq implements IteratorAggregate, Countable
     public function take($count)
     {
         if ($count == 0) {
-            return new Linq(array());
+            return new Linq([]);
         }
 
         return new Linq(new \LimitIterator($this->iterator, 0, $count));
@@ -438,7 +438,7 @@ class Linq implements IteratorAggregate, Countable
     {
         LinqHelper::assertArgumentIsIterable($second, "second");
 
-        $allItems = new \ArrayIterator(array($this->iterator, $second));
+        $allItems = new \ArrayIterator([$this->iterator, $second]);
 
         return new Linq(new SelectManyIterator($allItems));
     }
@@ -690,7 +690,7 @@ class Linq implements IteratorAggregate, Countable
         } elseif ($keySelector == null) {
             return iterator_to_array(new SelectIterator($this->getIterator(), $valueSelector), false);
         } else {
-            $array = array();
+            $array = [];
             foreach ($this as $value) {
                 $key = $keySelector($value);
                 $array[$key] = $valueSelector == null ? $value : $valueSelector($value);

--- a/src/Fusonic/Linq/Linq.php
+++ b/src/Fusonic/Linq/Linq.php
@@ -83,10 +83,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Filters the Linq object according to func return result.
      *
-     * @param callback $func    A func that returns boolean
+     * @param callable $func    A func that returns boolean
      * @return Linq             Filtered results according to $func
      */
-    public function where($func)
+    public function where(callable $func)
     {
         return new Linq(new WhereIterator($this->iterator, $func));
     }
@@ -145,12 +145,12 @@ class Linq implements IteratorAggregate, Countable
      * The first element of source is used as the initial aggregate value if $seed parameter is not specified.
      * If $seed is specified, this value will be used as the first value.
      *
-     * @param   callback $func An accumulator function to be invoked on each element.
+     * @param   callable $func An accumulator function to be invoked on each element.
      * @param   mixed $seed
      * @throws \RuntimeException if the input sequence contains no elements.
      * @return  mixed       Returns the final result of $func.
      */
-    public function aggregate($func, $seed = null)
+    public function aggregate(callable $func, $seed = null)
     {
         $result = null;
         $first = true;
@@ -193,10 +193,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Determines whether all elements satisfy a condition.
      *
-     * @param callback $func    A function to test each element for a condition.
+     * @param callable $func    A function to test each element for a condition.
      * @return bool             True if every element passes the test in the specified func, or if the sequence is empty; otherwise, false.
      */
-    public function all($func)
+    public function all(callable $func)
     {
         foreach ($this->iterator as $current) {
             $match = LinqHelper::getBoolOrThrowException($func($current));
@@ -210,10 +210,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Determines whether any element exists or satisfies a condition by invoking $func.
      *
-     * @param callback $func    A function to test each element for a condition or NULL to determine if any element exists.
+     * @param callable $func    A function to test each element for a condition or NULL to determine if any element exists.
      * @return bool             True if no $func given and the source sequence contains any elements or True if any elements passed the test in the specified func; otherwise, false.
      */
-    public function any($func = null)
+    public function any(callable $func = null)
     {
         foreach ($this->iterator as $current) {
             if ($func === null) {
@@ -244,11 +244,11 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Computes the average of all numeric values. Uses $func to obtain the value on each element.
      *
-     * @param callback $func    A func that returns any numeric type (int, float etc.)
+     * @param callable $func    A func that returns any numeric type (int, float etc.)
      * @throws \UnexpectedValueException if an item of the sequence is not a numeric value.
      * @return double        Average of items
      */
-    public function average($func = null)
+    public function average(callable $func = null)
     {
         $resultTotal = 0;
         $itemCount = 0;
@@ -269,10 +269,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Sorts the elements in ascending order according to a key provided by $func.
      *
-     * @param callback $func    A function to extract a key from an element.
+     * @param callable $func    A function to extract a key from an element.
      * @return Linq             A new Linq instance whose elements are sorted ascending according to a key.
      */
-    public function orderBy($func)
+    public function orderBy(callable $func)
     {
         return $this->order($func, LinqHelper::LINQ_ORDER_ASC);
     }
@@ -280,10 +280,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Sorts the elements in descending order according to a key provided by $func.
      *
-     * @param callback $func    A function to extract a key from an element.
+     * @param callable $func    A function to extract a key from an element.
      * @return Linq             A new Linq instance whose elements are sorted descending according to a key.
      */
-    public function orderByDescending($func)
+    public function orderByDescending(callable $func)
     {
         return $this->order($func, LinqHelper::LINQ_ORDER_DESC);
     }
@@ -296,11 +296,11 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Gets the sum of all items or by invoking a transform function on each item to get a numeric value.
      *
-     * @param callback $func    A func that returns any numeric type (int, float etc.) from the given element, or NULL to use the element itself.
+     * @param callable $func    A func that returns any numeric type (int, float etc.) from the given element, or NULL to use the element itself.
      * @throws \UnexpectedValueException if any element is not a numeric value.
      * @return  double         The sum of all items.
      */
-    public function sum($func = null)
+    public function sum(callable $func = null)
     {
         $sum = 0;
         $iterator = $this->getSelectIteratorOrInnerIterator($func);
@@ -317,12 +317,12 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Gets the minimum item value of all items or by invoking a transform function on each item to get a numeric value.
      *
-     * @param callback $func    A func that returns any numeric type (int, float etc.) from the given element, or NULL to use the element itself.
+     * @param callable $func    A func that returns any numeric type (int, float etc.) from the given element, or NULL to use the element itself.
      * @throws \RuntimeException if the sequence contains no elements
      * @throws \UnexpectedValueException
      * @return  double Minimum item value
      */
-    public function min($func = null)
+    public function min(callable $func = null)
     {
         $min = null;
         $iterator = $this->getSelectIteratorOrInnerIterator($func);
@@ -348,12 +348,12 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Returns the maximum item value according to $func
      *
-     * @param callback $func    A func that returns any numeric type (int, float etc.)
+     * @param callable $func    A func that returns any numeric type (int, float etc.)
      * @throws \RuntimeException if the sequence contains no elements
      * @throws \UnexpectedValueException if any element is not a numeric value or a string.
      * @return double          Maximum item value
      */
-    public function max($func = null)
+    public function max(callable $func = null)
     {
         $max = null;
         $iterator = $this->getSelectIteratorOrInnerIterator($func);
@@ -379,10 +379,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Projects each element into a new form by invoking the selector function.
      *
-     * @param callback $func    A transform function to apply to each element.
+     * @param callable $func    A transform function to apply to each element.
      * @return Linq             A new Linq object whose elements are the result of invoking the transform function on each element of the original Linq object.
      */
-    public function select($func)
+    public function select(callable $func)
     {
         return new Linq(new SelectIterator($this->iterator, $func));
     }
@@ -390,21 +390,21 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Projects each element of a sequence to a new Linq and flattens the resulting sequences into one sequence.
      *
-     * @param callback $func    A func that returns a sequence (array, Linq, Iterator).
+     * @param callable $func    A func that returns a sequence (array, Linq, Iterator).
      * @throws \UnexpectedValueException if an element is not a traversable sequence.
      * @return Linq             A new Linq object whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public function selectMany($func)
+    public function selectMany(callable $func)
     {
         return new Linq(new SelectManyIterator(new SelectIterator($this->iterator, $func)));
     }
 
     /**
      * Immediately performs the specified action on each element of the Linq sequence.
-     * @param callback $func    A func that will be evaluated for each item in the linq sequence.
+     * @param callable $func    A func that will be evaluated for each item in the linq sequence.
      * @return void
      */
-    public function each($func)
+    public function each(callable $func)
     {
         foreach ($this->iterator as $item) {
             $func($item);
@@ -446,10 +446,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Returns distinct item values of this
      *
-     * @param callback $func
+     * @param callable $func
      * @return Linq Distinct item values of this
      */
-    public function distinct($func = null)
+    public function distinct(callable $func = null)
     {
         return new Linq(new DistinctIterator($this->getSelectIteratorOrInnerIterator($func)));
     }
@@ -523,10 +523,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Groups the object according to the $func generated key
      *
-     * @param callback $keySelector    a func that returns an item as key, item can be any type.
+     * @param callable $keySelector    a func that returns an item as key, item can be any type.
      * @return GroupedLinq
      */
-    public function groupBy($keySelector)
+    public function groupBy(callable $keySelector)
     {
         return new Linq(new GroupIterator($this->iterator, $keySelector));
     }
@@ -535,10 +535,10 @@ class Linq implements IteratorAggregate, Countable
      * Returns the last element that satisfies a specified condition.
      * @throws \RuntimeException if no element satisfies the condition in predicate or the source sequence is empty.
      *
-     * @param callback  $func a func that returns boolean.
+     * @param callable  $func a func that returns boolean.
      * @return  Object Last item in this
      */
-    public function last($func = null)
+    public function last(callable $func = null)
     {
         return $this->getLast($func, true);
     }
@@ -546,10 +546,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Returns the last element that satisfies a condition or NULL if no such element is found.
      *
-     * @param callback  $func a func that returns boolean.
+     * @param callable  $func a func that returns boolean.
      * @return mixed
      */
-    public function lastOrNull($func = null)
+    public function lastOrNull(callable $func = null)
     {
         return $this->getLast($func, false);
     }
@@ -558,10 +558,10 @@ class Linq implements IteratorAggregate, Countable
      * Returns the first element that satisfies a specified condition
      * @throws \RuntimeException if no element satisfies the condition in predicate -or- the source sequence is empty / does not match any elements.
      *
-     * @param callback $func a func that returns boolean.
+     * @param callable $func a func that returns boolean.
      * @return mixed
      */
-    public function first($func = null)
+    public function first(callable $func = null)
     {
         return $this->getFirst($func, true);
     }
@@ -569,10 +569,10 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Returns the first element, or NULL if the sequence contains no elements.
      *
-     * @param callback $func    a func that returns boolean.
+     * @param callable $func    a func that returns boolean.
      * @return mixed
      */
-    public function firstOrNull($func = null)
+    public function firstOrNull(callable $func = null)
     {
         return $this->getFirst($func, false);
     }
@@ -581,10 +581,10 @@ class Linq implements IteratorAggregate, Countable
      * Returns the only element that satisfies a specified condition.
      *
      * @throws \RuntimeException if no element exists or if more than one element exists.
-     * @param callback $func    a func that returns boolean.
+     * @param callable $func    a func that returns boolean.
      * @return mixed
      */
-    public function single($func = null)
+    public function single(callable $func = null)
     {
         return $this->getSingle($func, true);
     }
@@ -593,10 +593,10 @@ class Linq implements IteratorAggregate, Countable
      * Returns the only element that satisfies a specified condition or NULL if no such element exists.
      *
      * @throws \RuntimeException if more than one element satisfies the condition.
-     * @param callback $func    a func that returns boolean.
+     * @param callable $func    a func that returns boolean.
      * @return mixed
      */
-    public function singleOrNull($func = null)
+    public function singleOrNull(callable $func = null)
     {
         return $this->getSingle($func, false);
     }
@@ -678,12 +678,12 @@ class Linq implements IteratorAggregate, Countable
     /**
      * Creates an Array from this Linq object with key/value selector(s).
      *
-     * @param callback $keySelector     a func that returns the array-key for each element.
-     * @param callback $valueSelector   a func that returns the array-value for each element.
+     * @param callable $keySelector     a func that returns the array-key for each element.
+     * @param callable $valueSelector   a func that returns the array-value for each element.
      *
      * @return Array    An array with all values.
      */
-    public function toArray($keySelector = null, $valueSelector = null)
+    public function toArray(callable $keySelector = null, callable $valueSelector = null)
     {
         if ($keySelector === null && $valueSelector === null) {
             return iterator_to_array($this, false);

--- a/tests/Fusonic/Linq/Test/AggregatesTest.php
+++ b/tests/Fusonic/Linq/Test/AggregatesTest.php
@@ -12,25 +12,25 @@ class AggregatesTest extends TestBase
     public function testSingle_TestBehaviour()
     {
         // more than one
-        $items = array(1, 2);
+        $items = [1, 2];
         $this->assertException(function () use ($items) {
             Linq::from($items)->single();
         });
 
         // no matching elements
-        $items = array();
+        $items = [];
         $this->assertException(function () use ($items) {
             Linq::from($items)->single();
         });
 
         // OK
-        $items = array(77);
+        $items = [77];
         $this->assertSame(77, Linq::from($items)->single());
 
         // With closure
 
         // more than one
-        $items = array(1, 2);
+        $items = [1, 2];
         $this->assertException(function () use ($items) {
             Linq::from($items)->single(function ($x) {
                 return true;
@@ -46,7 +46,7 @@ class AggregatesTest extends TestBase
         });
 
         // because of empty array
-        $items = array();
+        $items = [];
         $this->assertException(function () use ($items) {
             Linq::from($items)->single(function ($x) {
                 return true;
@@ -54,7 +54,7 @@ class AggregatesTest extends TestBase
         });
 
         // OK
-        $items = array(77);
+        $items = [77];
         $this->assertSame(77, Linq::from($items)->single(function ($x) {
             return true;
         }));
@@ -62,20 +62,20 @@ class AggregatesTest extends TestBase
 
     public function testCount_ReturnsCorrectAmounts()
     {
-        $items = array(1, 2);
+        $items = [1, 2];
         $this->assertEquals(2, Linq::from($items)->count());
 
-        $items = array(1, 2);
+        $items = [1, 2];
         $this->assertEquals(1, Linq::from($items)->where(function ($x) {
             return $x == 2;
         })->count());
 
-        $items = array(1, 2);
+        $items = [1, 2];
         $this->assertEquals(0, Linq::from($items)->where(function ($x) {
             return false;
         })->count());
 
-        $items = array();
+        $items = [];
         $this->assertEquals(0, Linq::from($items)->count());
     }
 
@@ -85,23 +85,23 @@ class AggregatesTest extends TestBase
     public function testSingleOrNull_TestBehaviour()
     {
         // more than one
-        $items = array(1, 2);
+        $items = [1, 2];
         $this->assertException(function () use ($items) {
             Linq::from($items)->singleOrNull();
         });
 
         // no matching elements
-        $items = array();
+        $items = [];
         $this->assertNull(Linq::from($items)->singleOrNull());
 
         // OK
-        $items = array(77);
+        $items = [77];
         $this->assertSame(77, Linq::from($items)->singleOrNull());
 
         // With closure
 
         // more than one
-        $items = array(1, 2);
+        $items = [1, 2];
         $this->assertException(function () use ($items) {
             Linq::from($items)->singleOrNull(function ($x) {
                 return true;
@@ -115,11 +115,11 @@ class AggregatesTest extends TestBase
         }));
 
         // because of empty array
-        $items = array();
+        $items = [];
         $this->assertNull(Linq::from($items)->singleOrNull());
 
         // OK
-        $items = array(77);
+        $items = [77];
         $this->assertSame(77, Linq::from($items)->singleOrNull(function ($x) {
             return true;
         }));
@@ -147,22 +147,22 @@ class AggregatesTest extends TestBase
         $c->value = "c";
 
         // more than one
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($a, Linq::from($items)->first());
 
         // no matching elements
-        $items = array();
+        $items = [];
         $this->assertException(function () use ($items) {
             Linq::from($items)->first();
         });
 
-        $items = array($a);
+        $items = [$a];
         $this->assertSame($a, Linq::from($items)->first());
 
         // #### With closures ###
 
         // more than one
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($b1, Linq::from($items)->first(function ($x) {
             return $x->value == "b";
         }));
@@ -176,7 +176,7 @@ class AggregatesTest extends TestBase
         });
 
         // because of empty array
-        $items = array();
+        $items = [];
         $this->assertException(function () use ($items) {
             Linq::from($items)->first(function ($x) {
                 return true;
@@ -184,7 +184,7 @@ class AggregatesTest extends TestBase
         });
 
         // OK
-        $items = array($a);
+        $items = [$a];
         $this->assertSame($a, Linq::from($items)->first(function ($x) {
             return true;
         }));
@@ -207,25 +207,25 @@ class AggregatesTest extends TestBase
         $c = new stdClass();
         $c->value = "c";
 
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($a, Linq::from($items)->firstOrNull());
 
-        $items = array();
+        $items = [];
         $this->assertNull(Linq::from($items)->firstOrNull());
 
         // #### With closures ###
 
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($b1, Linq::from($items)->firstOrNull(function ($x) {
             return $x->value == "b";
         }));
 
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($c, Linq::from($items)->firstOrNull(function ($x) {
             return $x->value == "c";
         }));
 
-        $items = array();
+        $items = [];
         $this->assertNull(Linq::from($items)->firstOrNull(function ($x) {
             return true;
         }));
@@ -246,23 +246,23 @@ class AggregatesTest extends TestBase
         $c->value = "c";
 
         // more than one
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $last = Linq::from($items)->last();
         $this->assertSame($c, $last);
 
         // no matching elements
-        $items = array();
+        $items = [];
         $this->assertException(function () use ($items) {
             Linq::from($items)->last();
         });
 
-        $items = array($a);
+        $items = [$a];
         $this->assertSame($a, Linq::from($items)->last());
 
         // #### With closures ###
 
         // more than one
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($b2, Linq::from($items)->last(function ($x) {
             return $x->value == "b";
         }));
@@ -276,7 +276,7 @@ class AggregatesTest extends TestBase
         });
 
         // because of empty array
-        $items = array();
+        $items = [];
         $this->assertException(function () use ($items) {
             Linq::from($items)->last(function ($x) {
                 return true;
@@ -284,7 +284,7 @@ class AggregatesTest extends TestBase
         });
 
         // OK
-        $items = array($a);
+        $items = [$a];
         $this->assertSame($a, Linq::from($items)->last(function ($x) {
             return true;
         }));
@@ -304,25 +304,25 @@ class AggregatesTest extends TestBase
         $c = new stdClass();
         $c->value = "c";
 
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($c, Linq::from($items)->lastOrNull());
 
-        $items = array();
+        $items = [];
         $this->assertNull(Linq::from($items)->lastOrNull());
 
         // #### With closures ###
 
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($c, Linq::from($items)->lastOrNull(function ($x) {
             return true;
         }));
 
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $this->assertSame($b2, Linq::from($items)->lastOrNull(function ($x) {
             return $x->value == "b";
         }));
 
-        $items = array();
+        $items = [];
         $this->assertNull(Linq::from($items)->lastOrNull(function ($x) {
             return true;
         }));
@@ -330,54 +330,54 @@ class AggregatesTest extends TestBase
 
     public function testElementAt_ReturnsElementAtPositionOrThrowsException()
     {
-        $items = array("a", "b", "c");
+        $items = ["a", "b", "c"];
         $this->assertEquals("a", Linq::from($items)->elementAt(0));
         $this->assertEquals("b", Linq::from($items)->elementAt(1));
         $this->assertEquals("c", Linq::from($items)->elementAt(2));
 
-        $items = array("a" => "aValue", "b" => "bValue");
+        $items = ["a" => "aValue", "b" => "bValue"];
         $this->assertEquals("aValue", Linq::from($items)->elementAt(0));
         $this->assertEquals("bValue", Linq::from($items)->elementAt(1));
 
         $this->assertException(function () {
-            $items = array();
+            $items = [];
             Linq::from($items)->elementAt(0);
         }, self::ExceptionName_OutOfRange);
 
         $this->assertException(function () {
-            $items = array();
+            $items = [];
             Linq::from($items)->elementAt(1);
         }, self::ExceptionName_OutOfRange);
 
         $this->assertException(function () {
-            $items = array();
+            $items = [];
             Linq::from($items)->elementAt(-1);
         }, self::ExceptionName_OutOfRange);
 
         $this->assertException(function () {
-            $items = array("a");
+            $items = ["a"];
             Linq::from($items)->elementAt(1);
         }, self::ExceptionName_OutOfRange);
 
         $this->assertException(function () {
-            $items = array("a", "b");
+            $items = ["a", "b"];
             Linq::from($items)->elementAt(2);
         }, self::ExceptionName_OutOfRange);
 
         $this->assertException(function () {
-            $items = array("a", "b");
+            $items = ["a", "b"];
             Linq::from($items)->elementAt(-1);
         }, self::ExceptionName_OutOfRange);
 
         $this->assertException(function () {
-            $items = array("a" => "value", "b" => "bValue");
+            $items = ["a" => "value", "b" => "bValue"];
             Linq::from($items)->elementAt(2);
         }, self::ExceptionName_OutOfRange);
     }
 
     public function testElementAtOrNull_ReturnsElementAtPositionOrNull()
     {
-        $items = array("a", "b", "c");
+        $items = ["a", "b", "c"];
         $this->assertEquals("a", Linq::from($items)->elementAtOrNull(0));
         $this->assertEquals("b", Linq::from($items)->elementAtOrNull(1));
         $this->assertEquals("c", Linq::from($items)->elementAtOrNull(2));
@@ -386,12 +386,12 @@ class AggregatesTest extends TestBase
         $this->assertNull(Linq::from($items)->elementAtOrNull(4));
         $this->assertNull(Linq::from($items)->elementAtOrNull(-1));
 
-        $items = array();
+        $items = [];
         $this->assertNull(Linq::from($items)->elementAtOrNull(3));
         $this->assertNull(Linq::from($items)->elementAtOrNull(4));
         $this->assertNull(Linq::from($items)->elementAtOrNull(-1));
 
-        $items = array("a" => "value", "b" => "bValue");
+        $items = ["a" => "value", "b" => "bValue"];
         $this->assertEquals("value", Linq::from($items)->elementAtOrNull(0));
         $this->assertNull(Linq::from($items)->elementAtOrNull(2));
     }
@@ -399,19 +399,19 @@ class AggregatesTest extends TestBase
     public function testAverage_throwsExceptionIfClosureReturnsNotNumericValue()
     {
         $this->assertException(function () {
-            $items = array(2, new stdClass());
+            $items = [2, new stdClass()];
             Linq::from($items)->average();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
-            $items = array(2, "no numeric value");
+            $items = [2, "no numeric value"];
             Linq::from($items)->average();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
             $cls = new stdClass();
             $cls->value = "no numeric value";
-            $items = array($cls);
+            $items = [$cls];
             Linq::from($items)->average(function ($x) {
                 return $x->value;
             });
@@ -420,25 +420,25 @@ class AggregatesTest extends TestBase
 
     public function testAverage_CalculatesCorrectAverage()
     {
-        $items = array(2, 4, 6);
+        $items = [2, 4, 6];
         $avg = Linq::from($items)->average();
         $this->assertEquals(4, $avg);
 
-        $items = array(2.5, 2.5);
+        $items = [2.5, 2.5];
         $avg = Linq::from($items)->average();
         $this->assertEquals(2.5, $avg);
 
-        $items = array(2, "4", "6");
+        $items = [2, "4", "6"];
         $avg = Linq::from($items)->average();
         $this->assertEquals(4, $avg);
 
-        $items = array(2, 4, 6);
+        $items = [2, 4, 6];
         $avg = Linq::from($items)->average(function ($v) {
             return 1;
         });
         $this->assertEquals(1, $avg);
 
-        $items = array(2.5, 2.5);
+        $items = [2.5, 2.5];
         $avg = Linq::from($items)->average(function ($v) {
             return $v;
         });
@@ -453,7 +453,7 @@ class AggregatesTest extends TestBase
         $c = new stdClass();
         $c->value = "6";
 
-        $items = array($a, $b, $c);
+        $items = [$a, $b, $c];
         $avg = Linq::from($items)->average(function ($v) {
             return $v->value;
         });
@@ -463,7 +463,7 @@ class AggregatesTest extends TestBase
     public function testAll_WorksCorrectly()
     {
         // All must always return true on empty sequences:
-        $items = array();
+        $items = [];
         $all = Linq::from($items)->all(function ($v) {
             return true;
         });
@@ -475,7 +475,7 @@ class AggregatesTest extends TestBase
         $this->assertTrue($all);
 
         // Test with values:
-        $items = array("a", "b");
+        $items = ["a", "b"];
         $all = Linq::from($items)->all(function ($v) {
             return $v == "a";
         });
@@ -490,7 +490,7 @@ class AggregatesTest extends TestBase
     public function testAny_WithFunc_CorrectResults()
     {
         // Any must always return false on empty sequences:
-        $items = array();
+        $items = [];
         $any = Linq::from($items)->any(function ($v) {
             return true;
         });
@@ -502,7 +502,7 @@ class AggregatesTest extends TestBase
         $this->assertFalse($any);
 
         // Test with values:
-        $items = array("a", "b");
+        $items = ["a", "b"];
         $any = Linq::from($items)->any(function ($v) {
             return $v == "not existing";
         });
@@ -516,57 +516,57 @@ class AggregatesTest extends TestBase
 
     public function testAny_WithoutFunc_CorrectResults()
     {
-        $items = array();
+        $items = [];
         $this->assertFalse(Linq::from($items)->any());
 
-        $items = array("a");
+        $items = ["a"];
         $this->assertTrue(Linq::from($items)->any());
 
-        $items = array("a", "b", "c");
+        $items = ["a", "b", "c"];
         $this->assertTrue(Linq::from($items)->any());
     }
 
     public function testMin_ReturnsMinValueFromNumerics()
     {
-        $items = array(88, 77, 12, 112);
+        $items = [88, 77, 12, 112];
         $min = Linq::from($items)->min();
         $this->assertEquals(12, $min);
 
-        $items = array(13);
+        $items = [13];
         $min = Linq::from($items)->min();
         $this->assertEquals(13, $min);
 
-        $items = array(0);
+        $items = [0];
         $min = Linq::from($items)->min();
         $this->assertEquals(0, $min);
 
-        $items = array(-12);
+        $items = [-12];
         $min = Linq::from($items)->min();
         $this->assertEquals(-12, $min);
 
-        $items = array(-12, 0, 100, -33);
+        $items = [-12, 0, 100, -33];
         $min = Linq::from($items)->min();
         $this->assertEquals(-33, $min);
     }
 
     public function testMin_ReturnsMinValueFromStrings()
     {
-        $items = array("c", "a", "b", "d");
+        $items = ["c", "a", "b", "d"];
         $min = Linq::from($items)->min();
         $this->assertEquals("a", $min);
 
-        $items = array("a");
+        $items = ["a"];
         $min = Linq::from($items)->min();
         $this->assertEquals("a", $min);
     }
 
     public function testMin_ReturnsMinValueFromDateTimes()
     {
-        $items = array(
+        $items = [
             new DateTime("2015-01-01 10:00:00"),
             new DateTime("2015-02-01 10:00:00"),
             new DateTime("2015-01-01 09:00:00"),
-        );
+        ];
         $min = Linq::from($items)->min();
         $this->assertEquals($items[2], $min);
     }
@@ -574,7 +574,7 @@ class AggregatesTest extends TestBase
     public function testMin_ThrowsExceptionIfSequenceIsEmpty()
     {
         $this->assertException(function () {
-            $data = array();
+            $data = [];
             $min = Linq::from($data)->min();
         });
     }
@@ -582,24 +582,24 @@ class AggregatesTest extends TestBase
     public function testMin_ThrowsExceptionIfSequenceContainsNoneNumericValuesOrStrings()
     {
         $this->assertException(function () {
-            $data = array(null);
+            $data = [null];
             $max = Linq::from($data)->min();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
-            $data = array(new stdClass());
+            $data = [new stdClass()];
             $min = Linq::from($data)->min();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
-            $data = array("string value", 1, new stdClass());
+            $data = ["string value", 1, new stdClass()];
             $min = Linq::from($data)->min();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
             $a = new stdClass();
             $a->nonNumeric = new stdClass();
-            $data = array($a);
+            $data = [$a];
             $min = Linq::from($data)->min(function ($x) {
                 return $x->nonNumeric;
             });
@@ -608,34 +608,34 @@ class AggregatesTest extends TestBase
 
     public function testMax_ReturnsMaxValueFromNumerics()
     {
-        $items = array(88, 77, 12, 112);
+        $items = [88, 77, 12, 112];
         $max = Linq::from($items)->max();
         $this->assertEquals(112, $max);
 
-        $items = array(13);
+        $items = [13];
         $max = Linq::from($items)->max();
         $this->assertEquals(13, $max);
 
-        $items = array(0);
+        $items = [0];
         $max = Linq::from($items)->max();
         $this->assertEquals(0, $max);
 
-        $items = array(-12);
+        $items = [-12];
         $max = Linq::from($items)->max();
         $this->assertEquals(-12, $max);
 
-        $items = array(-12, 0, 100, -33);
+        $items = [-12, 0, 100, -33];
         $max = Linq::from($items)->max();
         $this->assertEquals(100, $max);
     }
 
     public function testMax_ReturnsMaxValueFromDateTimes()
     {
-        $items = array(
+        $items = [
             new DateTime("2015-01-01 10:00:00"),
             new DateTime("2015-02-01 10:00:00"),
             new DateTime("2015-01-01 09:00:00"),
-        );
+        ];
         $max = Linq::from($items)->max();
         $this->assertEquals($items[1], $max);
     }
@@ -643,17 +643,17 @@ class AggregatesTest extends TestBase
     public function testSum_ThrowsExceptionIfSequenceContainsNoneNumericValues()
     {
         $this->assertException(function () {
-            $data = array(null);
+            $data = [null];
             $max = Linq::from($data)->sum();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
-            $data = array(new stdClass());
+            $data = [new stdClass()];
             $min = Linq::from($data)->sum();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
-            $data = array("string value", 1, new stdClass());
+            $data = ["string value", 1, new stdClass()];
             $min = Linq::from($data)->sum();
         }, self::ExceptionName_UnexpectedValue);
 
@@ -665,7 +665,7 @@ class AggregatesTest extends TestBase
             $b->value = 133;
             $a->nonNumeric = "asdf";
 
-            $data = array($a, $b);
+            $data = [$a, $b];
             $sum = Linq::from($data)->sum(function ($x) {
                 return $x->nonNumeric;
             });
@@ -674,19 +674,19 @@ class AggregatesTest extends TestBase
 
     public function testSum_GetSumOfValues()
     {
-        $data = array();
+        $data = [];
         $sum = Linq::from($data)->sum();
         $this->assertEquals(0, $sum);
 
-        $data = array(4, 9, 100.77);
+        $data = [4, 9, 100.77];
         $sum = Linq::from($data)->sum();
         $this->assertEquals(113.77, $sum);
 
-        $data = array(12, -12);
+        $data = [12, -12];
         $sum = Linq::from($data)->sum();
         $this->assertEquals(0, $sum);
 
-        $data = array(12, -24);
+        $data = [12, -24];
         $sum = Linq::from($data)->sum();
         $this->assertEquals(-12, $sum);
 
@@ -695,7 +695,7 @@ class AggregatesTest extends TestBase
         $b = new stdClass();
         $b->value = 133;
 
-        $data = array($a, $b);
+        $data = [$a, $b];
         $sum = Linq::from($data)->sum(function ($x) {
             return $x->value;
         });
@@ -705,11 +705,11 @@ class AggregatesTest extends TestBase
 
     public function testMax_ReturnsMaxValueFromStrings()
     {
-        $items = array("c", "a", "b", "d");
+        $items = ["c", "a", "b", "d"];
         $max = Linq::from($items)->max();
         $this->assertEquals("d", $max);
 
-        $items = array("a");
+        $items = ["a"];
         $max = Linq::from($items)->max();
         $this->assertEquals("a", $max);
     }
@@ -717,7 +717,7 @@ class AggregatesTest extends TestBase
     public function testMax_ThrowsExceptionIfSequenceIsEmpty()
     {
         $this->assertException(function () {
-            $data = array();
+            $data = [];
             $max = Linq::from($data)->max();
         });
     }
@@ -725,24 +725,24 @@ class AggregatesTest extends TestBase
     public function testMax_ThrowsExceptionIfSequenceContainsNoneNumericValuesOrStrings()
     {
         $this->assertException(function () {
-            $data = array(new stdClass());
+            $data = [new stdClass()];
             $max = Linq::from($data)->max();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
-            $data = array(null);
+            $data = [null];
             $max = Linq::from($data)->max();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
-            $data = array("string value", 1, new stdClass());
+            $data = ["string value", 1, new stdClass()];
             $max = Linq::from($data)->max();
         }, self::ExceptionName_UnexpectedValue);
 
         $this->assertException(function () {
             $a = new stdClass();
             $a->nonNumeric = new stdClass();
-            $data = array($a);
+            $data = [$a];
             $min = Linq::from($data)->max(function ($x) {
                 return $x->nonNumeric;
             });
@@ -753,48 +753,48 @@ class AggregatesTest extends TestBase
     {
         $this->assertException(function () {
 
-            Linq::from(array())->aggregate(function () {
+            Linq::from([])->aggregate(function () {
             });
         }, self::ExceptionName_Runtime);
 
 
         $this->assertException(function () {
 
-            Linq::from(array())->aggregate(function () {
+            Linq::from([])->aggregate(function () {
             }, null);
         }, self::ExceptionName_Runtime);
     }
 
     public function testAggregate_returnsCorrectResult()
     {
-        $this->assertEquals("value", Linq::from(array("value"))->aggregate(function ($a, $b) {
+        $this->assertEquals("value", Linq::from(["value"])->aggregate(function ($a, $b) {
             throw new Exception("Must not becalled");
         }));
-        $this->assertEquals(2, Linq::from(array(2))->aggregate(function ($a, $b) {
+        $this->assertEquals(2, Linq::from([2])->aggregate(function ($a, $b) {
             throw new Exception("Must not becalled");
         }));
-        $this->assertEquals(5, Linq::from(array(2, 3))->aggregate(function ($a, $b) {
+        $this->assertEquals(5, Linq::from([2, 3])->aggregate(function ($a, $b) {
             return $a + $b;
         }));
-        $this->assertEquals(17, Linq::from(array(2, 3, 3, 4, 5))->aggregate(function ($a, $b) {
+        $this->assertEquals(17, Linq::from([2, 3, 3, 4, 5])->aggregate(function ($a, $b) {
             return $a + $b;
         }));
-        $this->assertEquals("abcde", Linq::from(array("a", "b", "c", "d", "e"))->aggregate(function ($a, $b) {
+        $this->assertEquals("abcde", Linq::from(["a", "b", "c", "d", "e"])->aggregate(function ($a, $b) {
             return $a . $b;
         }));
     }
 
     public function testAggregate_withSeedValue_returnsCorrectResult()
     {
-        $this->assertEquals(9999, Linq::from(array())->aggregate(function () {
+        $this->assertEquals(9999, Linq::from([])->aggregate(function () {
         }, 9999));
-        $this->assertEquals(104, Linq::from(array(2))->aggregate(function ($a, $b) {
+        $this->assertEquals(104, Linq::from([2])->aggregate(function ($a, $b) {
             return $a + $b;
         }, 102));
-        $this->assertEquals(137, Linq::from(array(2, 2, 20, 11))->aggregate(function ($a, $b) {
+        $this->assertEquals(137, Linq::from([2, 2, 20, 11])->aggregate(function ($a, $b) {
             return $a + $b;
         }, 102));
-        $this->assertEquals("begin_abcde", Linq::from(array("a", "b", "c", "d", "e"))->aggregate(function ($a, $b) {
+        $this->assertEquals("begin_abcde", Linq::from(["a", "b", "c", "d", "e"])->aggregate(function ($a, $b) {
             return $a . $b;
         }, "begin_"));
     }

--- a/tests/Fusonic/Linq/Test/ChunkTest.php
+++ b/tests/Fusonic/Linq/Test/ChunkTest.php
@@ -61,25 +61,25 @@ class ChunkTest extends TestBase
     public function testChunk_throwsException_IfchunksizeIsInvalid()
     {
         $this->assertException(function () {
-            Linq::from(array())->chunk(0);
+            Linq::from([])->chunk(0);
         }, self::ExceptionName_InvalidArgument);
 
         $this->assertException(function () {
-            Linq::from(array())->chunk(-1);
+            Linq::from([])->chunk(-1);
         }, self::ExceptionName_InvalidArgument);
     }
 
     public function testChunk_ReturnsChunkedElementsAccordingToChunksize()
     {
-        $groups = Linq::from(array())->chunk(2);
+        $groups = Linq::from([])->chunk(2);
         $this->assertEquals(0, $groups->count());
 
-        $groups = Linq::from(array("a"))->chunk(2);
+        $groups = Linq::from(["a"])->chunk(2);
         $this->assertEquals(1, $groups->count());
         $this->assertEquals(1, $groups->ElementAt(0)->count());
         $this->assertEquals("a", $groups->ElementAt(0)->ElementAt(0));
 
-        $groups = Linq::from(array("a", "b", "c", "d", "e"))->chunk(2);
+        $groups = Linq::from(["a", "b", "c", "d", "e"])->chunk(2);
         $this->assertEquals(3, $groups->count());
         $this->assertEquals(2, $groups->ElementAt(0)->count());
         $this->assertEquals("a", $groups->ElementAt(0)->ElementAt(0));
@@ -92,16 +92,16 @@ class ChunkTest extends TestBase
         $this->assertEquals(1, $groups->ElementAt(2)->count());
         $this->assertEquals("e", $groups->ElementAt(2)->ElementAt(0));
 
-        $groups = Linq::from(array("a", "b", "c", "d", "e"))->chunk(3);
+        $groups = Linq::from(["a", "b", "c", "d", "e"])->chunk(3);
         $this->assertEquals(2, $groups->count());
 
-        $groups = Linq::from(array("a", "b", "c", "d", "e"))->chunk(4);
+        $groups = Linq::from(["a", "b", "c", "d", "e"])->chunk(4);
         $this->assertEquals(2, $groups->count());
 
-        $groups = Linq::from(array("a", "b", "c", "d", "e"))->chunk(5);
+        $groups = Linq::from(["a", "b", "c", "d", "e"])->chunk(5);
         $this->assertEquals(1, $groups->count());
 
-        $groups = Linq::from(array("a", "b", "c", "d", "e"))->chunk(117);
+        $groups = Linq::from(["a", "b", "c", "d", "e"])->chunk(117);
         $this->assertEquals(1, $groups->count());
     }
 }

--- a/tests/Fusonic/Linq/Test/GroupingTest.php
+++ b/tests/Fusonic/Linq/Test/GroupingTest.php
@@ -20,7 +20,7 @@ class GroupingTest extends TestBase
         $b1->id = 3;
         $b1->value = "b";
 
-        $items = array($a1, $a2, $b1);
+        $items = [$a1, $a2, $b1];
         $grouped = Linq::from($items)->groupBy(function ($x) {
             return $x->value;
         });

--- a/tests/Fusonic/Linq/Test/MiscTest.php
+++ b/tests/Fusonic/Linq/Test/MiscTest.php
@@ -11,7 +11,7 @@ class MiscTest extends TestBase
 {
     public function testCountable_implementedSqlInterface()
     {
-        $items = array(1, 2, 3);
+        $items = [1, 2, 3];
 
         $matching = Linq::from($items);
 
@@ -21,8 +21,8 @@ class MiscTest extends TestBase
 
     public function testConcat_ReturnsConcatenatedElements()
     {
-        $first = array("a", "b");
-        $second = array("c", "d");
+        $first = ["a", "b"];
+        $second = ["c", "d"];
 
         $all = Linq::from($first)->concat($second);
         $this->assertTrue($all instanceof Linq);
@@ -39,13 +39,13 @@ class MiscTest extends TestBase
     public function testConcat_ThrowsArgumentExceptionIfNoTraversableArgument()
     {
         $this->assertException(function () {
-            $input = array();
+            $input = [];
             $linq = Linq::from($input);
             $linq->concat(null);
         }, self::ExceptionName_InvalidArgument);
 
         $this->assertException(function () {
-            $input = array();
+            $input = [];
             $second = new stdClass();
             Linq::from($input)->concat($second);
         }, self::ExceptionName_InvalidArgument);
@@ -53,15 +53,15 @@ class MiscTest extends TestBase
 
     public function testLinqFrom_WorksWith_Arrays_Iterators_And_IteratorAggregates()
     {
-        $linq = Linq::from(array(1, 2));
+        $linq = Linq::from([1, 2]);
         $linq = Linq::from($linq);
         $linq = Linq::from($linq->getIterator());
     }
 
     public function testEach_PerformsActionOnEachElement()
     {
-        $items = array("a", "b", "c");
-        $looped = array();
+        $items = ["a", "b", "c"];
+        $looped = [];
         Linq::from($items)
             ->each(function ($x) use (&$looped) {
                 $looped[] = $x;
@@ -75,7 +75,7 @@ class MiscTest extends TestBase
 
     public function testEach_ReturnsVoid()
     {
-        $linq = Linq::from(array(1, 2, 3, 4))
+        $linq = Linq::from([1, 2, 3, 4])
             ->skip(2)->take(1);
 
         $linqAfterEach = $linq->each(function ($x) {
@@ -85,7 +85,7 @@ class MiscTest extends TestBase
 
     public function testContains_defaultComparison()
     {
-        $items = array("2", 2);
+        $items = ["2", 2];
         $linq = Linq::from($items);
         $this->assertTrue($linq->contains(2));
         $this->assertTrue($linq->contains("2"));
@@ -100,7 +100,7 @@ class MiscTest extends TestBase
         $a = new stdClass();
         $b = new stdClass();
         $c = new stdClass();
-        $linq = Linq::from(array($a, $b));
+        $linq = Linq::from([$a, $b]);
         $this->assertTrue($linq->contains($a));
         $this->assertTrue($linq->contains($b));
         $this->assertFalse($linq->contains($c));

--- a/tests/Fusonic/Linq/Test/OfTypeTest.php
+++ b/tests/Fusonic/Linq/Test/OfTypeTest.php
@@ -13,7 +13,7 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_empty_array()
     {
         /** @var array $result */
-        $result = Linq::from(array())
+        $result = Linq::from([])
             ->ofType('StubInterface')
             ->toArray();
 
@@ -30,8 +30,7 @@ class OfTypeTest extends TestBase
         $expectedResult = new Stub();
 
         /** @var array $result */
-        $result = Linq::from(array($expectedResult,
-            new StubWithoutInterface()))
+        $result = Linq::from([$expectedResult, new StubWithoutInterface()])
             ->ofType('StubInterface')
             ->toArray();
 
@@ -49,8 +48,7 @@ class OfTypeTest extends TestBase
         $expectedResult1 = new StubWithoutInterface();
 
         /** @var array $result */
-        $result = Linq::from(array(new Stub(),
-            $expectedResult1))
+        $result = Linq::from([new Stub(), $expectedResult1])
             ->ofType('StubWithoutInterface')
             ->toArray();
 
@@ -61,8 +59,7 @@ class OfTypeTest extends TestBase
         /** @var StubWithoutInterface $expectedResult2 */
         $expectedResult2 = new Stub();
 
-        $result = Linq::from(array($expectedResult2,
-            new StubWithoutInterface()))
+        $result = Linq::from([$expectedResult2, new StubWithoutInterface()])
             ->ofType('Stub')
             ->toArray();
 
@@ -77,8 +74,7 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_array_not_containing_expected_interface()
     {
         /** @var array $result */
-        $result = Linq::from(array(new StubWithoutInterface(),
-            new StubWithoutInterface()))
+        $result = Linq::from([new StubWithoutInterface(), new StubWithoutInterface()])
             ->ofType('StubInterface')
             ->toArray();
 
@@ -92,8 +88,7 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_array_not_containing_expected_object_type()
     {
         /** @var array $result */
-        $result = Linq::from(array(new Stub(),
-            new Stub()))
+        $result = Linq::from([new Stub(), new Stub()])
             ->ofType('StubWithoutInterface')
             ->toArray();
 
@@ -107,8 +102,7 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_unknown_interface()
     {
         /** @var array $result */
-        $result = Linq::from(array(new Stub(),
-            new Stub()))
+        $result = Linq::from([new Stub(), new Stub()])
             ->ofType('UnknownInterface')
             ->toArray();
 
@@ -122,8 +116,7 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_unknown_object_type()
     {
         /** @var array $result */
-        $result = Linq::from(array(new Stub(),
-            new Stub()))
+        $result = Linq::from([new Stub(), new Stub()])
             ->ofType('UnknownObject')
             ->toArray();
 
@@ -137,17 +130,17 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_int_as_type()
     {
         /** @var int[] $expectedResult */
-        $expectedResult = array(1,
+        $expectedResult = [1,
             2,
             10,
-            20);
+            20];
 
-        $result = Linq::from(array(1,
+        $result = Linq::from([1,
             2,
             new Stub(),
             10,
             NULL,
-            20))
+            20])
             ->ofType('int')
             ->toArray();
 
@@ -161,15 +154,15 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_bool_as_type()
     {
         /** @var int[] $expectedResult */
-        $expectedResult = array(TRUE,
-            FALSE);
+        $expectedResult = [TRUE,
+            FALSE];
 
-        $result = Linq::from(array(0,
+        $result = Linq::from([0,
             'string',
             'true',
             TRUE,
             'false',
-            FALSE))
+            FALSE])
             ->ofType('bool')
             ->toArray();
 
@@ -183,16 +176,16 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_string_as_type()
     {
         /** @var int[] $expectedResult */
-        $expectedResult = array('string',
+        $expectedResult = ['string',
             'true',
-            'false');
+            'false'];
 
-        $result = Linq::from(array(0,
+        $result = Linq::from([0,
             'string',
             'true',
             TRUE,
             'false',
-            FALSE))
+            FALSE])
             ->ofType('string')
             ->toArray();
 
@@ -206,17 +199,17 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_float_as_type()
     {
         /** @var int[] $expectedResult */
-        $expectedResult = array(2.5,
+        $expectedResult = [2.5,
             10.0,
-            0.3);
+            0.3];
 
-        $result = Linq::from(array(0,
+        $result = Linq::from([0,
             'string',
             2.5,
             10.0,
             11,
             'false',
-            0.3))
+            0.3])
             ->ofType('float')
             ->toArray();
 
@@ -230,18 +223,18 @@ class OfTypeTest extends TestBase
     public function when_ofType_is_called_with_double_as_type()
     {
         /** @var int[] $expectedResult */
-        $expectedResult = array(2.5,
+        $expectedResult = [2.5,
             10.0,
-            0.3);
+            0.3];
 
-        $result = Linq::from(array(0,
+        $result = Linq::from([0,
             'string',
             2.5,
             10.0,
             NULL,
             11,
             'false',
-            0.3))
+            0.3])
             ->ofType('double')
             ->toArray();
 

--- a/tests/Fusonic/Linq/Test/OrderTest.php
+++ b/tests/Fusonic/Linq/Test/OrderTest.php
@@ -15,7 +15,7 @@ class OrderTest extends TestBase
         $b->value = 10;
         $c = new stdClass();
         $c->value = 20;
-        $items = array($a, $b, $c);
+        $items = [$a, $b, $c];
 
         $ascending = Linq::from($items)->orderBy(function ($x) {
             return $x->value;
@@ -35,7 +35,7 @@ class OrderTest extends TestBase
         $c->value = 20;
         $d = new stdClass();
         $d->value = 20;
-        $items = array($a, $b, $c, $d);
+        $items = [$a, $b, $c, $d];
 
         $ascending = Linq::from($items)->orderBy(function ($x) {
             return $x->value;
@@ -57,7 +57,7 @@ class OrderTest extends TestBase
 
     public function testOrderBy_NumericValues_ReturnsCorrectOrders()
     {
-        $items = array(77, 10, 20);
+        $items = [77, 10, 20];
         $ascending = Linq::from($items)->orderBy(function ($x) {
             return $x;
         });
@@ -74,7 +74,7 @@ class OrderTest extends TestBase
         $this->assertEquals(10, $items[1]);
         $this->assertEquals(20, $items[2]);
 
-        $items = array(12.33, 8.21, 11.3, 8.21, 33);
+        $items = [12.33, 8.21, 11.3, 8.21, 33];
         $ascending = Linq::from($items)->orderBy(function ($x) {
             return $x;
         });
@@ -89,7 +89,7 @@ class OrderTest extends TestBase
 
     public function testOrderBy_StringValues_ReturnsCorrectOrders()
     {
-        $items = array("e", "a", "c");
+        $items = ["e", "a", "c"];
         $ascending = Linq::from($items)->orderBy(function ($x) {
             return $x;
         });
@@ -108,7 +108,7 @@ class OrderTest extends TestBase
 
     public function testOrderBy_DateTimeValues_ReturnsCorrectOrders()
     {
-        $items = array(new DateTime("27.10.2011"), new DateTime("03.04.2012"), new DateTime("01.01.2005"));
+        $items = [new DateTime("27.10.2011"), new DateTime("03.04.2012"), new DateTime("01.01.2005")];
         $ascending = Linq::from($items)->orderBy(function ($x) {
             return $x;
         });
@@ -127,7 +127,7 @@ class OrderTest extends TestBase
 
     public function testOrderByDescending_NumericValues_ReturnsCorrectOrders()
     {
-        $items = array(77, 10, 20);
+        $items = [77, 10, 20];
         $desc = Linq::from($items)->orderByDescending(function ($x) {
             return $x;
         });
@@ -143,7 +143,7 @@ class OrderTest extends TestBase
         $this->assertEquals(10, $items[1]);
         $this->assertEquals(20, $items[2]);
 
-        $items = array(12.33, 8.21, 11.3, 8.21, 33);
+        $items = [12.33, 8.21, 11.3, 8.21, 33];
         $desc = Linq::from($items)->orderByDescending(function ($x) {
             return $x;
         });
@@ -163,7 +163,7 @@ class OrderTest extends TestBase
         $b->value = 10;
         $c = new stdClass();
         $c->value = 20;
-        $items = array($a, $b, $c);
+        $items = [$a, $b, $c];
 
         $ascending = Linq::from($items)->orderByDescending(function ($x) {
             return $x->value;
@@ -183,7 +183,7 @@ class OrderTest extends TestBase
         $c->value = 20;
         $d = new stdClass();
         $d->value = 20;
-        $items = array($a, $b, $c, $d);
+        $items = [$a, $b, $c, $d];
 
         $ascending = Linq::from($items)->orderByDescending(function ($x) {
             return $x->value;
@@ -204,7 +204,7 @@ class OrderTest extends TestBase
 
     public function testOrderByDescending_DateTimeValues_ReturnsCorrectOrders()
     {
-        $items = array(new DateTime("27.10.2011"), new DateTime("03.04.2012"), new DateTime("01.01.2005"));
+        $items = [new DateTime("27.10.2011"), new DateTime("03.04.2012"), new DateTime("01.01.2005")];
         $desc = Linq::from($items)->orderByDescending(function ($x) {
             return $x;
         });
@@ -223,7 +223,7 @@ class OrderTest extends TestBase
 
     public function testOrderBy_Descending_StringValues_ReturnsCorrectOrders()
     {
-        $items = array("e", "a", "c");
+        $items = ["e", "a", "c"];
         $desc = Linq::from($items)->orderByDescending(function ($x) {
             return $x;
         });
@@ -242,7 +242,7 @@ class OrderTest extends TestBase
 
     public function testOrderBy_DoesMakeLazyEvalution()
     {
-        $items = array("e", "a", "c");
+        $items = ["e", "a", "c"];
         $eval = false;
         $linq = Linq::from($items)->orderByDescending(function ($x) use (&$eval) {
             $eval = true;
@@ -256,7 +256,7 @@ class OrderTest extends TestBase
 
     public function testIssue3_emtpyCollectionOrdering()
     {
-        Linq::from(array())
+        Linq::from([])
             ->orderBy(function (array $x) {
                 return $x["name"];
             })

--- a/tests/Fusonic/Linq/Test/ProjectionTest.php
+++ b/tests/Fusonic/Linq/Test/ProjectionTest.php
@@ -18,7 +18,7 @@ class ProjectionTest extends TestBase
         $a4->value = "a4";
 
         // more than one
-        $items = array($a1, $a2, $a3, $a4);
+        $items = [$a1, $a2, $a3, $a4];
 
         $projected = Linq::from($items)->select(function ($v) {
             return $v->value;
@@ -33,7 +33,7 @@ class ProjectionTest extends TestBase
         $this->assertEquals("a3", $projected[2]);
         $this->assertEquals("a4", $projected[3]);
 
-        $items = array();
+        $items = [];
 
         $projected = Linq::from($items)->select(function ($v) {
             return $v->value;
@@ -46,7 +46,7 @@ class ProjectionTest extends TestBase
     {
         $a1 = new stdClass();
         $a1->value = "a1";
-        $items = array($a1);
+        $items = [$a1];
 
         $this->assertException(function () use ($items) {
             Linq::from($items)->selectMany(function ($v) {
@@ -65,10 +65,10 @@ class ProjectionTest extends TestBase
     public function testSelectMany_ReturnsFlattenedSequence()
     {
         $a1 = new stdClass();
-        $a1->value = array("a", "b");
+        $a1->value = ["a", "b"];
         $a2 = new stdClass();
-        $a2->value = array("c", "d");
-        $items = array($a1, $a2);
+        $a2->value = ["c", "d"];
+        $items = [$a1, $a2];
 
         $linq = Linq::from($items)->selectMany(function ($x) {
             return $x->value;
@@ -96,7 +96,7 @@ class ProjectionTest extends TestBase
 
     public function testSelectMany_EmptySequence_ReturnsEmptySequence()
     {
-        $linq = Linq::from(array())->selectMany(function ($x) {
+        $linq = Linq::from([])->selectMany(function ($x) {
             return $x->value;
         });
 
@@ -113,10 +113,10 @@ class ProjectionTest extends TestBase
     public function testSelectMany_DoesLazyEvaluation()
     {
         $a1 = new stdClass();
-        $a1->value = array("a", "b");
+        $a1->value = ["a", "b"];
         $a2 = new stdClass();
-        $a2->value = array("c", "d");
-        $items = array($a1, $a2);
+        $a2->value = ["c", "d"];
+        $items = [$a1, $a2];
 
         $eval = false;
         $flattened = Linq::from($items)->selectMany(function ($x) use (&$eval) {

--- a/tests/Fusonic/Linq/Test/SetOperatorsTest.php
+++ b/tests/Fusonic/Linq/Test/SetOperatorsTest.php
@@ -9,8 +9,8 @@ class SetOperators extends TestBase
 {
     public function testIntersect_ReturnsIntersectedElements()
     {
-        $first = array("a", "b", "c", "d");
-        $second = array("b", "c");
+        $first = ["a", "b", "c", "d"];
+        $second = ["b", "c"];
 
         $linq = Linq::from($first)->intersect($second);
         $this->assertEquals(2, $linq->count());
@@ -29,8 +29,8 @@ class SetOperators extends TestBase
         $b1->id = 3;
         $b1->value = "b";
 
-        $items = array($a1, $a2, $b1);
-        $distinct = Linq::from($items)->intersect(array($a2, $b1));
+        $items = [$a1, $a2, $b1];
+        $distinct = Linq::from($items)->intersect([$a2, $b1]);
 
         $this->assertFalse($distinct->contains($a1));
         $this->assertTrue($distinct->contains($a2));
@@ -40,13 +40,13 @@ class SetOperators extends TestBase
     public function testIntersect_ThrowsArgumentExceptionIfSecondSequenceIsNotTraversable()
     {
         $this->assertException(function () {
-            $input = array();
+            $input = [];
             $linq = Linq::from($input);
             $linq->intersect(null);
         }, self::ExceptionName_InvalidArgument);
 
         $this->assertException(function () {
-            $input = array();
+            $input = [];
             $linq = Linq::from($input);
             $linq->intersect("Not a sequence");
         }, self::ExceptionName_InvalidArgument);
@@ -54,8 +54,8 @@ class SetOperators extends TestBase
 
     public function testIntersect_EmptySequence_ReturnsEmptySequence()
     {
-        $first = array("a", "b", "c", "d");
-        $second = array();
+        $first = ["a", "b", "c", "d"];
+        $second = [];
 
         $linq = Linq::from($first)->intersect($second);
         $this->assertEquals(0, $linq->count());
@@ -65,8 +65,8 @@ class SetOperators extends TestBase
 
     public function testExcept_ReturnsAllElementsExceptTheGivenOnes()
     {
-        $first = array("a", "b", "c", "d");
-        $second = array("b", "c");
+        $first = ["a", "b", "c", "d"];
+        $second = ["b", "c"];
 
         $linq = Linq::from($first)->except($second);
         $this->assertEquals(2, $linq->count());
@@ -85,8 +85,8 @@ class SetOperators extends TestBase
         $b1->id = 3;
         $b1->value = "b";
 
-        $items = array($a1, $a2, $b1);
-        $distinct = Linq::from($items)->except(array($a2, $b1));
+        $items = [$a1, $a2, $b1];
+        $distinct = Linq::from($items)->except([$a2, $b1]);
 
         $this->assertTrue($distinct->contains($a1));
         $this->assertFalse($distinct->contains($a2));
@@ -96,13 +96,13 @@ class SetOperators extends TestBase
     public function testExcept_ThrowsArgumentExceptionIfSecondSequenceIsNotTraversable()
     {
         $this->assertException(function () {
-            $input = array();
+            $input = [];
             $linq = Linq::from($input);
             $linq->except(null);
         }, self::ExceptionName_InvalidArgument);
 
         $this->assertException(function () {
-            $input = array();
+            $input = [];
             $linq = Linq::from($input);
             $linq->except("Not a sequence");
         }, self::ExceptionName_InvalidArgument);
@@ -110,8 +110,8 @@ class SetOperators extends TestBase
 
     public function testExcept_EmptySequence_ReturnsAllElementsFromFirst()
     {
-        $first = array("a", "b", "c", "d");
-        $second = array();
+        $first = ["a", "b", "c", "d"];
+        $second = [];
 
         $linq = Linq::from($first)->except($second);
         $this->assertEquals(4, $linq->count());
@@ -125,7 +125,7 @@ class SetOperators extends TestBase
 
     public function testDistinct_ReturnsDistinctElements()
     {
-        $items = array("a", "b", "a", "b");
+        $items = ["a", "b", "a", "b"];
 
         $distinct = Linq::from($items)->distinct();
         $this->assertTrue($distinct instanceof Linq);
@@ -145,7 +145,7 @@ class SetOperators extends TestBase
         $b1->id = 3;
         $b1->value = "b";
 
-        $items = array($a1, $a2, $b1);
+        $items = [$a1, $a2, $b1];
         $distinct = Linq::from($items)->distinct(function ($v) {
             return $v->value;
         });
@@ -162,7 +162,7 @@ class SetOperators extends TestBase
         $a2->id = 2;
         $a2->value = "a";
 
-        $items = array($a1, $a2);
+        $items = [$a1, $a2];
         $distinct = Linq::from($items)->distinct(function ($v) use (&$eval) {
             $eval = true;
             return $v->value;

--- a/tests/Fusonic/Linq/Test/SetTest.php
+++ b/tests/Fusonic/Linq/Test/SetTest.php
@@ -54,8 +54,8 @@ class SetTest extends TestBase
     public function add_array_addsObjectAndReturnsTrueIfObjectDoesNotExist_OtherwiseFalse()
     {
         $set = new Set();
-        $a = array("a1", "a2");
-        $b = array("b1", "b2");
+        $a = ["a1", "a2"];
+        $b = ["b1", "b2"];
 
         $this->assertFalse($set->contains($a));
         $this->assertTrue($set->add($a));
@@ -149,8 +149,8 @@ class SetTest extends TestBase
     public function remove_array_returnTrueIfObjectExistsAndRemoveIt_OtherwiseReturnFalse()
     {
         $set = new Set();
-        $a = array("a1", "a2");
-        $b = array("b1", "b2");
+        $a = ["a1", "a2"];
+        $b = ["b1", "b2"];
 
         $set->add($a);
         $set->add($b);
@@ -199,7 +199,7 @@ class SetTest extends TestBase
         $a = null;
         $b = "string";
         $c = new stdClass();
-        $d = array("a", "b", "c");
+        $d = ["a", "b", "c"];
 
         $this->assertTrue($set->add($a));
         $this->assertTrue($set->add($b));

--- a/tests/Fusonic/Linq/Test/SkipTakeTest.php
+++ b/tests/Fusonic/Linq/Test/SkipTakeTest.php
@@ -8,7 +8,7 @@ class SkipTakeTest extends TestBase
 {
     public function testSkipWithTake_Combined_SkipAndTakeValuesByAmount()
     {
-        $items = array("a", "b", "c", "d", "e", "f");
+        $items = ["a", "b", "c", "d", "e", "f"];
         $matching = Linq::from($items)->skip(2)->take(0);
         $this->assertEquals(0, $matching->count());
 
@@ -36,7 +36,7 @@ class SkipTakeTest extends TestBase
 
     public function testTakeSkip_Combined_TakeAndSkipValuesByAmount()
     {
-        $items = array("a", "b", "c", "d", "e", "f");
+        $items = ["a", "b", "c", "d", "e", "f"];
         $matching = Linq::from($items)->take(0)->skip(0);
         $this->assertEquals(0, $matching->count());
 
@@ -52,7 +52,7 @@ class SkipTakeTest extends TestBase
 
     public function testSkip_SkipValuesByAmount()
     {
-        $items = array("a", "b", "c", "d", "e", "f");
+        $items = ["a", "b", "c", "d", "e", "f"];
         $matching = Linq::from($items)->skip(2);
         $this->assertTrue($matching instanceof Linq);
 
@@ -64,7 +64,7 @@ class SkipTakeTest extends TestBase
         $this->assertTrue(in_array("e", $matching));
         $this->assertTrue(in_array("f", $matching));
 
-        $items = array("a", "b", "c", "d", "e", "f");
+        $items = ["a", "b", "c", "d", "e", "f"];
 
         $matching = Linq::from($items)->skip(0);
         $this->assertEquals(6, $matching->count());
@@ -89,16 +89,16 @@ class SkipTakeTest extends TestBase
 
         // Test against empty sequence:
 
-        $matching = Linq::from(array())->skip(0);
+        $matching = Linq::from([])->skip(0);
         $this->assertEquals(0, $matching->count());
 
-        $matching = Linq::from(array())->skip(6);
+        $matching = Linq::from([])->skip(6);
         $this->assertEquals(0, $matching->count());
     }
 
     public function testTake_TakeValuesByAmount()
     {
-        $items = array("a", "b", "c", "d", "e", "f");
+        $items = ["a", "b", "c", "d", "e", "f"];
         $matching = Linq::from($items)->take(4);
         $this->assertTrue($matching instanceof Linq);
 

--- a/tests/Fusonic/Linq/Test/ToArrayTest.php
+++ b/tests/Fusonic/Linq/Test/ToArrayTest.php
@@ -9,7 +9,7 @@ class ToArrayTest extends TestBase
 {
     public function testToArray_WithoutKeySelector_ReturnsIteratorValuesAsArray_UsesDefaultNumericArrayKeys()
     {
-        $linq = Linq::from(array("a", "b", "c"))
+        $linq = Linq::from(["a", "b", "c"])
             ->skip(1)->take(3);
 
         $array = $linq->toArray();
@@ -26,7 +26,7 @@ class ToArrayTest extends TestBase
 
     public function testToArray_WithKeySelector_ReturnsIteratorValuesAsArray_UsesKeySelectorValueAsKey()
     {
-        $linq = Linq::from(array("a", "b", "c"))
+        $linq = Linq::from(["a", "b", "c"])
             ->skip(1)->take(3);
 
         $array = $linq->toArray(function ($x) {
@@ -46,10 +46,10 @@ class ToArrayTest extends TestBase
 
     public function testToArray_WithKeyAndValueSelector_ReturnsArrayWithKeyValueSetsFromClosures()
     {
-        $source = array(
-            array("catId" => 11, "name" => "Category11", "additionalcolumn" => "foo"),
-            array("catId" => 12, "name" => "Category12", "additionalcolumn" => "bar"),
-        );
+        $source = [
+            ["catId" => 11, "name" => "Category11", "additionalcolumn" => "foo"],
+            ["catId" => 12, "name" => "Category12", "additionalcolumn" => "bar"],
+        ];
         $linq = Linq::from($source);
 
         $array = $linq->toArray(function ($x) {
@@ -71,10 +71,10 @@ class ToArrayTest extends TestBase
 
     public function testToArray_WithValueSelector_ReturnsArrayWithDefaultNumericKey_AndValueFromClosure()
     {
-        $source = array(
-            array("catId" => 11, "name" => "Category11", "additionalcolumn" => "foo"),
-            array("catId" => 12, "name" => "Category12", "additionalcolumn" => "bar"),
-        );
+        $source = [
+            ["catId" => 11, "name" => "Category11", "additionalcolumn" => "foo"],
+            ["catId" => 12, "name" => "Category12", "additionalcolumn" => "bar"],
+        ];
 
         $linq = Linq::from($source);
 
@@ -95,9 +95,9 @@ class ToArrayTest extends TestBase
 
     public function testMethodsWithSequencesAsArguments_WorkWith_Arrays_Iterators_And_IteratorAggregates()
     {
-        $first = Linq::from(array("a", "b"));
-        $secondArray = array("c", "d");
-        $secondLinq = Linq::from(array("c", "d"));
+        $first = Linq::from(["a", "b"]);
+        $secondArray = ["c", "d"];
+        $secondLinq = Linq::from(["c", "d"]);
         $secondIterator = $secondLinq->getIterator();
 
         $res = $first->concat($secondLinq)->toArray();

--- a/tests/Fusonic/Linq/Test/WhereTest.php
+++ b/tests/Fusonic/Linq/Test/WhereTest.php
@@ -20,7 +20,7 @@ class WhereTest extends TestBase
         $c = new stdClass();
         $c->value = "c";
 
-        $items = array($a, $b1, $b2, $c);
+        $items = [$a, $b1, $b2, $c];
         $matching = Linq::from($items)->where(function ($v) {
             return false;
         });
@@ -52,7 +52,7 @@ class WhereTest extends TestBase
     public function testWhere_ThrowsExceptionIfPredicateDoesNotReturnABoolean()
     {
         $this->assertException(function () {
-            $items = array("1", "2", "3");
+            $items = ["1", "2", "3"];
             $matching = Linq::from($items)->where(function ($v) {
                 return "NOT A BOOLEAN";
             });
@@ -63,7 +63,7 @@ class WhereTest extends TestBase
     public function testWhere_DoesLazyEvaluation()
     {
         $eval = false;
-        $items = array("1", "2", "3");
+        $items = ["1", "2", "3"];
         $matching = Linq::from($items)->where(function ($v) use (&$eval) {
             $eval = true;
             return true;
@@ -76,7 +76,7 @@ class WhereTest extends TestBase
 
     public function testWhere_EmptySequence_ReturnsEmptySequence()
     {
-        $items = array();
+        $items = [];
         $matching = Linq::from($items)->where(function ($v) {
             return true;
         });


### PR DESCRIPTION
This PR updates the code to use two PHP 5.4 features:

1. Use of short array syntax `[$x]` instead of `array($x)`
2. Add type-hints for `callable` on all methods that expect one