### PR TITLE
Prevent array type being picked up as missing class

### DIFF
--- a/src/Fusonic/Linq/Linq.php
+++ b/src/Fusonic/Linq/Linq.php
@@ -681,7 +681,7 @@ class Linq implements IteratorAggregate, Countable
      * @param callable $keySelector     a func that returns the array-key for each element.
      * @param callable $valueSelector   a func that returns the array-value for each element.
      *
-     * @return Array    An array with all values.
+     * @return array    An array with all values.
      */
     public function toArray(callable $keySelector = null, callable $valueSelector = null)
     {


### PR DESCRIPTION
The `@return Array` typehint was being picked up as a missing class `Fusonic\Linq\Array`, so changed to lower-case.