### PR TITLE
Fix problem using IteratorAggregates with skip and take

### DIFF
--- a/src/Fusonic/Linq/Linq.php
+++ b/src/Fusonic/Linq/Linq.php
@@ -91,17 +91,17 @@ class Linq implements IteratorAggregate, Countable
         return new Linq(new WhereIterator($this->iterator, $func));
     }
 
-	/**
-	 * Filters the Linq object according to type.
-	 *
-	 * @param string $type
-	 *
-	 * @return Linq Filtered results according to $func
-	 */
-	public function ofType($type)
-	{
-		return new Linq(new OfTypeIterator($this->iterator, $type));
-	}
+    /**
+     * Filters the Linq object according to type.
+     *
+     * @param string $type
+     *
+     * @return Linq Filtered results according to $func
+     */
+    public function ofType($type)
+    {
+        return new Linq(new OfTypeIterator($this->iterator, $type));
+    }
 
     /**
      * Bypasses a specified number of elements and then returns the remaining elements.
@@ -120,7 +120,8 @@ class Linq implements IteratorAggregate, Countable
             }
         }
 
-        return new Linq(new \LimitIterator($innerIterator, $count, -1));
+        // IteratorIterator wraps $innerIterator because it might be Traversable but not an Iterator.
+        return new Linq(new \LimitIterator(new \IteratorIterator($innerIterator), $count, -1));
     }
 
     /**
@@ -135,7 +136,8 @@ class Linq implements IteratorAggregate, Countable
             return new Linq([]);
         }
 
-        return new Linq(new \LimitIterator($this->iterator, 0, $count));
+        // IteratorIterator wraps $this->iterator because it might be Traversable but not an Iterator.
+        return new Linq(new \LimitIterator(new \IteratorIterator($this->iterator), 0, $count));
     }
 
     /**

--- a/tests/Fusonic/Linq/Test/SkipTakeTest.php
+++ b/tests/Fusonic/Linq/Test/SkipTakeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once("TestBase.php");
+require_once __DIR__ . '/TestIteratorAggregate.php';
 
 use Fusonic\Linq\Linq;
 
@@ -111,5 +112,23 @@ class SkipTakeTest extends TestBase
 
         $matching = Linq::from($items)->take(0);
         $this->assertEquals(0, $matching->count());
+    }
+
+    public function testTake_WithIteratorAggregate()
+    {
+        $items = new TestIteratorAggregate(["a", "b", "c", "d", "e", "f"]);
+        $matching = Linq::from($items)->take(4);
+
+        $this->assertTrue($matching instanceof Linq);
+        $this->assertEquals(4, $matching->count());
+    }
+
+    public function testSkip_WithIteratorAggregate()
+    {
+        $items = new TestIteratorAggregate(["a", "b", "c", "d", "e", "f"]);
+        $matching = Linq::from($items)->skip(2);
+
+        $this->assertTrue($matching instanceof Linq);
+        $this->assertEquals(4, $matching->count());
     }
 }

--- a/tests/Fusonic/Linq/Test/TestIteratorAggregate.php
+++ b/tests/Fusonic/Linq/Test/TestIteratorAggregate.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @property array x
+ */
+class TestIteratorAggregate implements \IteratorAggregate
+{
+    public function __construct(array $x)
+    {
+        $this->x = $x;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->x);
+    }
+}


### PR DESCRIPTION
Summary of changes:

- Added a `TestIteratorAggregate` class
- Added test cases for skip and take (plus minor whitespace edit tabs vs spaces)
- Added IteratorIterator wrapper with explanatory comment

I hope that will do until a safer LimitIterator implementation materialises.