### PR TITLE
Fixed issue with InvalidArgumentException when a string is passed as chunk-size

### DIFF
--- a/src/Fusonic/Linq/Linq.php
+++ b/src/Fusonic/Linq/Linq.php
@@ -195,7 +195,7 @@ class Linq implements IteratorAggregate, Countable
     public function chunk($chunksize)
     {
         if ($chunksize < 1) {
-            throw new \InvalidArgumentException("chunksize", $chunksize);
+            throw new \InvalidArgumentException("'{$chunksize}' is not a valid chunk size.");
         }
 
         return Linq::from(new ChunkIterator($this->iterator, $chunksize));

--- a/tests/Fusonic/Linq/Test/ChunkTest.php
+++ b/tests/Fusonic/Linq/Test/ChunkTest.php
@@ -67,6 +67,14 @@ class ChunkTest extends TestBase
         $this->assertException(function () {
             Linq::from([])->chunk(-1);
         }, self::ExceptionName_InvalidArgument);
+
+        $this->assertException(function () {
+            Linq::from([])->chunk(null);
+        }, self::ExceptionName_InvalidArgument);
+
+        $this->assertException(function () {
+            Linq::from([])->chunk("");
+        }, self::ExceptionName_InvalidArgument);
     }
 
     public function testChunk_ReturnsChunkedElementsAccordingToChunksize()


### PR DESCRIPTION
`InvalidArgumentException` has been used incorrectly in this case. It only takes a message argument. When passing in a string, PHP will crash with the following exception:

```
PHP Fatal error: Uncaught Error: Wrong parameters for InvalidArgumentException([string $message [, long $code [, Throwable $previous = NULL]]]) in /var/www/project/vendor/fusonic/linq/src/Fusonic/Linq/Linq.php:186
```